### PR TITLE
Add player deletion view and UI

### DIFF
--- a/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
+++ b/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
@@ -88,12 +88,12 @@
 
                            
                     
-                    <button class="btn btn-danger btn-sm" data-bs-toggle="modal"
-                            data-bs-target="#modalConfirmarEliminarJugador"
-                            data-id="{{ j.id }}"
-                            title="Eliminar">
+                    <button class="btn btn-danger btn-sm" onclick="confirmarEliminacionJugador({{ j.id }})" title="Eliminar">
                         <i class="bi bi-trash"></i>
                     </button>
+                    <form id="form-eliminar-jugador-{{ j.id }}" method="POST" action="{% url 'delete_jugador' j.id %}">
+                        {% csrf_token %}
+                    </form>
                 </td>
             </tr>
             {% endfor %}
@@ -610,5 +610,29 @@
 
 
   </script>
-  
+
+  <script>
+    // Confirmar eliminación con iziToast
+    function confirmarEliminacionJugador(id) {
+      iziToast.question({
+        timeout: 3000,
+        close: false,
+        overlay: true,
+        displayMode: 'once',
+        title: '¿Estás seguro?',
+        message: 'Esta acción eliminará el jugador de forma permanente.',
+        position: 'center',
+        buttons: [
+          ['<button><b>Sí, eliminar</b></button>', function (instance, toast) {
+            document.getElementById('form-eliminar-jugador-' + id).submit();
+            instance.hide({}, toast);
+          }, true],
+          ['<button>Cancelar</button>', function (instance, toast) {
+            instance.hide({}, toast);
+          }]
+        ]
+      });
+    }
+  </script>
+
 {% endblock %}

--- a/Aplicaciones/Entrenamientos/urls.py
+++ b/Aplicaciones/Entrenamientos/urls.py
@@ -54,10 +54,8 @@ urlpatterns = [
     # -------------------------------CRUD JUGADORES-----------------------------
     path('jugadores/', views.list_jugadores, name='list_jugadores'),
     path('jugadores/add/', views.add_jugador, name='add_jugador'),
-    path('jugadores/editar/', views.edit_jugador, name='edit_jugador')
-    
-
-    #path('jugadores/delete/<int:pk>/', views.delete_jugador, name='delete_jugador'),
+    path('jugadores/editar/', views.edit_jugador, name='edit_jugador'),
+    path('jugadores/delete/<int:pk>/', views.delete_jugador, name='delete_jugador'),
 
     
 

--- a/Aplicaciones/Entrenamientos/views.py
+++ b/Aplicaciones/Entrenamientos/views.py
@@ -1051,5 +1051,30 @@ def edit_jugador(request):
         return redirect('list_jugadores')
 
 
+@login_required
+def delete_jugador(request, pk):
+    if request.user.rol_usu not in ['admin_dios', 'admin', 'entrenador']:
+        messages.error(request, "No tienes permiso para eliminar jugadores.")
+        return redirect('list_jugadores')
+
+    if request.method == 'POST':
+        jugador = get_object_or_404(Jugador, pk=pk)
+
+        if jugador.prueba_set.exists() or jugador.resultadomacro_set.exists():
+            messages.error(request, "No se puede eliminar el jugador porque tiene registros asociados.")
+            return redirect('list_jugadores')
+
+        usuario = jugador.fk_id_usu
+        try:
+            jugador.delete()
+            if usuario:
+                TokenPassword.objects.filter(fk_id_usu=usuario).delete()
+                usuario.delete()
+            messages.success(request, "Jugador eliminado correctamente.")
+        except ProtectedError:
+            messages.error(request, "No se puede eliminar el jugador porque tiene registros protegidos.")
+        return redirect('list_jugadores')
+
+    
 
 


### PR DESCRIPTION
## Summary
- implement delete_jugador view with relationship checks
- wire up delete_jugador route
- add delete forms and confirmation dialog in listJugadores template

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f83d20a30832abed0af44605533c7