### PR TITLE
Add validation for jugadores form

### DIFF
--- a/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
+++ b/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
@@ -466,10 +466,10 @@
   });
 </script>
 
-<script>
-  $(document).ready(function () {
-      // Inicializar DataTable para la tabla de Categorías
-      $('#tbl_jugadores').DataTable({
+  <script>
+    $(document).ready(function () {
+        // Inicializar DataTable para la tabla de Categorías
+        $('#tbl_jugadores').DataTable({
           dom: '<"d-flex justify-content-between align-items-center mb-3"<"dt-buttons"B><"dataTables_filter"f>>' +
               '<"row"<"col-12"tr>>' +
               '<"d-flex justify-content-between align-items-center"<"dataTables_info"i><"dataTables_paginate"p>>',
@@ -508,9 +508,252 @@
           language: {
               url: "https://cdn.datatables.net/plug-ins/1.13.6/i18n/es-ES.json"
           }
-      });
-  });
-</script>
+        });
+    });
+  </script>
+
+  <script>
+    $(document).ready(function () {
+        $.validator.addMethod("regex", function(value, element, regexp) {
+            var re = new RegExp(regexp);
+            return this.optional(element) || re.test(value);
+        }, "Formato inválido.");
+
+        // Solo números en teléfono y cédula
+        $('input[name="telefono_usu"], #edit_telefono, input[name="cedula_usu"], #edit_cedula').on('input', function () {
+            this.value = this.value.replace(/[^0-9]/g, '');
+        });
+
+        // Solo letras en nombres y apellidos
+        $('input[name="nombres_usu"], input[name="primer_apellido_usu"], input[name="segundo_apellido_usu"], #edit_nombres, #edit_papellido, #edit_sapellido').on('input', function () {
+            this.value = this.value.replace(/[^A-Za-zÁÉÍÓÚáéíóúÑñ ]/g, '');
+        });
+
+        // Resetear modalAgregarJugador
+        $('#modalAgregarJugador').on('hidden.bs.modal', function () {
+            const form = $("#modalAgregarJugador form")[0];
+            form.reset();
+            $("#modalAgregarJugador form").validate().resetForm();
+            $(form).find('.form-control').removeClass('is-valid is-invalid');
+        });
+
+        // Validar formulario AGREGAR
+        $("#modalAgregarJugador form").validate({
+            errorClass: 'is-invalid',
+            validClass: 'is-valid',
+            errorElement: 'div',
+            errorPlacement: function (error, element) {
+                error.addClass('invalid-feedback');
+                error.insertAfter(element);
+            },
+            rules: {
+                correo_usu: {
+                    required: true,
+                    email: true,
+                    remote: {
+                        url: "/validate_correo/",
+                        type: "get",
+                        data: {
+                            correo_usu: function() {
+                                return $("input[name='correo_usu']").val();
+                            }
+                        }
+                    }
+                },
+                telefono_usu: {
+                    required: true,
+                    digits: true,
+                    minlength: 10,
+                    maxlength: 10
+                },
+                cedula_usu: {
+                    required: true,
+                    digits: true,
+                    minlength: 10,
+                    maxlength: 10,
+                    remote: {
+                        url: "/validate_cedula/",
+                        type: "get",
+                        data: {
+                            cedula_usu: function() {
+                                return $("input[name='cedula_usu']").val();
+                            }
+                        }
+                    }
+                },
+                nombres_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                primer_apellido_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                segundo_apellido_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                direccion_usu: {
+                    required: true,
+                    minlength: 3
+                }
+            },
+            messages: {
+                correo_usu: {
+                    required: "El correo es obligatorio.",
+                    email: "Ingrese un correo válido.",
+                    remote: "Este correo ya está registrado."
+                },
+                telefono_usu: {
+                    required: "El teléfono es obligatorio.",
+                    digits: "Solo se permiten números.",
+                    minlength: "Debe tener 10 dígitos.",
+                    maxlength: "Debe tener 10 dígitos."
+                },
+                cedula_usu: {
+                    required: "La cédula es obligatoria.",
+                    digits: "Solo se permiten números.",
+                    minlength: "Debe tener 10 dígitos.",
+                    maxlength: "Debe tener 10 dígitos.",
+                    remote: "Esta cédula ya está registrada."
+                },
+                nombres_usu: {
+                    required: "Los nombres son obligatorios.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                primer_apellido_usu: {
+                    required: "Este campo es obligatorio.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                segundo_apellido_usu: {
+                    required: "Este campo es obligatorio.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                direccion_usu: {
+                    required: "La dirección es obligatoria.",
+                    minlength: "Debe tener al menos 3 caracteres."
+                }
+            }
+        });
+
+        // Validar formulario EDITAR
+        $("#formEditarJugador").validate({
+            errorClass: 'is-invalid',
+            validClass: 'is-valid',
+            errorElement: 'div',
+            errorPlacement: function (error, element) {
+                error.addClass('invalid-feedback');
+                error.insertAfter(element);
+            },
+            rules: {
+                correo_usu: {
+                    required: true,
+                    email: true,
+                    remote: {
+                        url: "/validate_correo/",
+                        type: "get",
+                        data: {
+                            correo_usu: function() {
+                                return $("#edit_correo").val();
+                            },
+                            exclude_id: function() {
+                                return $("#edit_id_usuario").val();
+                            }
+                        }
+                    }
+                },
+                telefono_usu: {
+                    required: true,
+                    digits: true,
+                    minlength: 10,
+                    maxlength: 10
+                },
+                cedula_usu: {
+                    required: true,
+                    digits: true,
+                    minlength: 10,
+                    maxlength: 10,
+                    remote: {
+                        url: "/validate_cedula/",
+                        type: "get",
+                        data: {
+                            cedula_usu: function() {
+                                return $("#edit_cedula").val();
+                            },
+                            exclude_id: function() {
+                                return $("#edit_id_usuario").val();
+                            }
+                        }
+                    }
+                },
+                nombres_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                primer_apellido_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                segundo_apellido_usu: {
+                    required: true,
+                    minlength: 3,
+                    regex: "^[A-Za-zÁÉÍÓÚáéíóúÑñ ]+$"
+                },
+                direccion_usu: {
+                    required: true,
+                    minlength: 3
+                }
+            },
+            messages: {
+                correo_usu: {
+                    required: "El correo es obligatorio.",
+                    email: "Ingrese un correo válido.",
+                    remote: "Este correo ya está registrado."
+                },
+                telefono_usu: {
+                    required: "El teléfono es obligatorio.",
+                    digits: "Solo se permiten números.",
+                    minlength: "Debe tener 10 dígitos.",
+                    maxlength: "Debe tener 10 dígitos."
+                },
+                cedula_usu: {
+                    required: "La cédula es obligatoria.",
+                    digits: "Solo se permiten números.",
+                    minlength: "Debe tener 10 dígitos.",
+                    maxlength: "Debe tener 10 dígitos.",
+                    remote: "Esta cédula ya está registrada."
+                },
+                nombres_usu: {
+                    required: "Los nombres son obligatorios.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                primer_apellido_usu: {
+                    required: "Este campo es obligatorio.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                segundo_apellido_usu: {
+                    required: "Este campo es obligatorio.",
+                    minlength: "Debe tener al menos 3 letras.",
+                    regex: "Solo letras y espacios."
+                },
+                direccion_usu: {
+                    required: "La dirección es obligatoria.",
+                    minlength: "Debe tener al menos 3 caracteres."
+                }
+            }
+        });
+    });
+  </script>
 
 
 


### PR DESCRIPTION
## Summary
- enhance `listJugadores.html` with jQuery Validation logic
- restrict phone and ID inputs to digits
- reset form state when closing the add modal

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f964c5cc8832aa259c21f4e4c9fa3