### PR TITLE
Fix player email validation

### DIFF
--- a/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
+++ b/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
@@ -740,10 +740,9 @@
                                 return $("#edit_correo").val();
                             },
                             exclude_id: function() {
-                                const correoActual = $("#edit_correo").val();
-                                const correoOriginal = $("#edit_correo").data('original');
-                                if (correoActual === correoOriginal) return '';  // ❌ No validar si no ha cambiado
-                                return $("#edit_id_usuario").val();              // ✅ Validar si cambió
+                                // Enviamos siempre el ID del usuario para que el backend ignore su propio registro al validar la unicidad del correo.
+                                // Esto evita falsos positivos cuando el usuario no ha modificado el correo.
+                                return $("#edit_id_usuario").val();
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- always send user id to email unique validation when editing players

## Testing
- `python manage.py check` *(fails: Error loading psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7e591f0832aab1dad35267c11a1