### PR TITLE
Fix player email/ID validation

### DIFF
--- a/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
+++ b/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
@@ -740,10 +740,9 @@
                                 return $("#edit_correo").val();
                             },
                             exclude_id: function() {
-                                const correoActual = $("#edit_correo").val();
-                                const correoOriginal = $("#edit_correo").data('original');
-                                if (correoActual === correoOriginal) return '';  // ❌ No validar si no ha cambiado
-                                return $("#edit_id_usuario").val();              // ✅ Validar si cambió
+                                // Enviamos siempre el ID del usuario para que el backend ignore su propio registro al validar la unicidad del correo.
+                                // Esto evita falsos positivos cuando el usuario no ha modificado el correo.
+                                return $("#edit_id_usuario").val();
                             }
                         }
                     }

--- a/Aplicaciones/Entrenamientos/views.py
+++ b/Aplicaciones/Entrenamientos/views.py
@@ -1028,13 +1028,17 @@ def edit_jugador(request):
         nuevo_correo = request.POST['correo_usu']
         nueva_cedula = request.POST['cedula_usu']
 
-        if Usuario.objects.exclude(pk=usuario.pk).filter(correo_usu=nuevo_correo).exists():
-            messages.error(request, "Este correo ya está registrado.")
-            return redirect('list_jugadores')
+        # Solo verificar duplicados si se modificó el dato. Esto evita errores
+        # cuando el usuario intenta guardar sin cambiar su correo o cédula.
+        if nuevo_correo != usuario.correo_usu:
+            if Usuario.objects.exclude(pk=usuario.pk).filter(correo_usu=nuevo_correo).exists():
+                messages.error(request, "Este correo ya está registrado.")
+                return redirect('list_jugadores')
 
-        if Usuario.objects.exclude(pk=usuario.pk).filter(cedula_usu=nueva_cedula).exists():
-            messages.error(request, "Esta cédula ya está registrada.")
-            return redirect('list_jugadores')
+        if nueva_cedula != usuario.cedula_usu:
+            if Usuario.objects.exclude(pk=usuario.pk).filter(cedula_usu=nueva_cedula).exists():
+                messages.error(request, "Esta cédula ya está registrada.")
+                return redirect('list_jugadores')
 
         usuario.correo_usu = nuevo_correo
         usuario.cedula_usu = nueva_cedula


### PR DESCRIPTION
## Summary
- avoid duplicate checks when editing a player if the email or ID hasn't changed

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_683fb7e591f0832aab1dad35267c11a1