### PR TITLE
Fix player edit duplicate check

### DIFF
--- a/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
+++ b/Aplicaciones/Entrenamientos/templates/Jugadores/listJugadores.html
@@ -740,11 +740,11 @@
                                 return $("#edit_correo").val();
                             },
                             exclude_id: function() {
-                                const correoActual = $("#edit_correo").val();
-                                const correoOriginal = $("#edit_correo").data('original');
-                                if (correoActual === correoOriginal) return '';  // ❌ No validar si no ha cambiado
-                                return $("#edit_id_usuario").val();              // ✅ Validar si cambió
+                                return $("#edit_id_usuario").val();
                             }
+                        },
+                        depends: function() {
+                            return $("#edit_correo").val() !== $("#edit_correo").data('original');
                         }
                     }
                 },
@@ -769,6 +769,9 @@
                             exclude_id: function() {
                                 return $("#edit_id_usuario").val();
                             }
+                        },
+                        depends: function() {
+                            return $("#edit_cedula").val() !== $("#edit_cedula").data('original');
                         }
                     }
                 },
@@ -854,7 +857,10 @@
   
           // Asignar valores a los campos
           setValue('#edit_id_jugador', button.dataset.id);
-          setValue('#edit_id_usuario', button.dataset.idusu);
+          // Obtener id del usuario con distintos posibles formatos en data-
+          // attributes por compatibilidad con versiones anteriores
+          const idUsuario = button.dataset.idusu || button.dataset.idUsuario || button.getAttribute('data-idusu');
+          setValue('#edit_id_usuario', idUsuario);
 
 
 

--- a/Aplicaciones/Entrenamientos/views.py
+++ b/Aplicaciones/Entrenamientos/views.py
@@ -1028,13 +1028,17 @@ def edit_jugador(request):
         nuevo_correo = request.POST['correo_usu']
         nueva_cedula = request.POST['cedula_usu']
 
-        if Usuario.objects.exclude(pk=usuario.pk).filter(correo_usu=nuevo_correo).exists():
-            messages.error(request, "Este correo ya está registrado.")
-            return redirect('list_jugadores')
+        # Solo verificar duplicados si se modificó el dato. Esto evita errores
+        # cuando el usuario intenta guardar sin cambiar su correo o cédula.
+        if nuevo_correo != usuario.correo_usu:
+            if Usuario.objects.exclude(pk=usuario.pk).filter(correo_usu=nuevo_correo).exists():
+                messages.error(request, "Este correo ya está registrado.")
+                return redirect('list_jugadores')
 
-        if Usuario.objects.exclude(pk=usuario.pk).filter(cedula_usu=nueva_cedula).exists():
-            messages.error(request, "Esta cédula ya está registrada.")
-            return redirect('list_jugadores')
+        if nueva_cedula != usuario.cedula_usu:
+            if Usuario.objects.exclude(pk=usuario.pk).filter(cedula_usu=nueva_cedula).exists():
+                messages.error(request, "Esta cédula ya está registrada.")
+                return redirect('list_jugadores')
 
         usuario.correo_usu = nuevo_correo
         usuario.cedula_usu = nueva_cedula


### PR DESCRIPTION
## Summary
- refine player edit modal JavaScript
- only run remote validations when email or ID changed

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683fb7e591f0832aab1dad35267c11a1